### PR TITLE
Moved plugin id to `com.diffplug.image-grinder`.

### DIFF
--- a/CHANGES.md
+++ b/CHANGES.md
@@ -2,8 +2,8 @@
 
 ## [Unreleased]
 ### Changed
-- Plugin id is now `com.diffplug.image-grinder`.
-    - You can still use the legacy `com.diffplug.gradle.image-grinder` if you want.
+- Plugin id is now `com.diffplug.image-grinder` ([reasoning](https://dev.to/nedtwigg/names-in-java-maven-and-gradle-2fm2#gradle-plugin-id)).
+    - You can still use the legacy `com.diffplug.gradle.image-grinder` if you want, but you'll get a deprecation warning.
 - Upgraded Batik from `1.11` to `1.12`.
 - Upgraded build to [blowdryer](https://github.com/diffplug/blowdryer).
 

--- a/CHANGES.md
+++ b/CHANGES.md
@@ -2,6 +2,8 @@
 
 ## [Unreleased]
 ### Changed
+- Plugin id is now `com.diffplug.image-grinder`.
+    - You can still use the legacy `com.diffplug.gradle.image-grinder` if you want.
 - Upgraded Batik from `1.11` to `1.12`.
 - Upgraded build to [blowdryer](https://github.com/diffplug/blowdryer).
 

--- a/README.md
+++ b/README.md
@@ -2,7 +2,7 @@
 
 <!---freshmark shields
 output = [
-    link(shield('Gradle plugin', 'plugins.gradle.org', 'com.diffplug.gradle.image-grinder', 'blue'), 'https://plugins.gradle.org/plugin/com.diffplug.gradle.image-grinder'),
+    link(shield('Gradle plugin', 'plugins.gradle.org', 'com.diffplug.image-grinder', 'blue'), 'https://plugins.gradle.org/plugin/com.diffplug.image-grinder'),
     link(shield('Maven central', 'mavencentral', 'available', 'blue'), 'https://search.maven.org/artifact/com.diffplug.gradle/image-grinder'),
     link(shield('Apache 2.0', 'license', 'apache-2.0', 'blue'), 'https://tldrlegal.com/license/apache-license-2.0-(apache-2.0)'),
     '',
@@ -12,7 +12,7 @@ output = [
     link(image('JitCI', 'https://jitci.com/gh/diffplug/image-grinder/svg'), 'https://jitci.com/gh/diffplug/image-grinder')
     ].join('\n');
 -->
-[![Gradle plugin](https://img.shields.io/badge/plugins.gradle.org-com.diffplug.gradle.image--grinder-blue.svg)](https://plugins.gradle.org/plugin/com.diffplug.gradle.image-grinder)
+[![Gradle plugin](https://img.shields.io/badge/plugins.gradle.org-com.diffplug.image--grinder-blue.svg)](https://plugins.gradle.org/plugin/com.diffplug.image-grinder)
 [![Maven central](https://img.shields.io/badge/mavencentral-available-blue.svg)](https://search.maven.org/artifact/com.diffplug.gradle/image-grinder)
 [![Apache 2.0](https://img.shields.io/badge/license-apache--2.0-blue.svg)](https://tldrlegal.com/license/apache-license-2.0-(apache-2.0))
 
@@ -28,7 +28,7 @@ output = prefixDelimiterReplace(input, 'https://javadoc.io/static/com.diffplug.g
 
 ## Simple image processing
 
-To use it, just [add image-grinder to your buildscript](https://plugins.gradle.org/plugin/com.diffplug.gradle.image-grinder), and configure it as so:
+To use it, just [add image-grinder to your buildscript](https://plugins.gradle.org/plugin/com.diffplug.image-grinder), and configure it as so:
 
 ```groovy
 imageGrinder {

--- a/build.gradle
+++ b/build.gradle
@@ -5,6 +5,7 @@ plugins {
 
 spotlessChangelog {
 	changelogFile 'CHANGES.md'
+	ifFoundBumpAdded '### Added', '### Changed'
 }
 apply from: 干.file('base/changelog.gradle')
 apply from: 干.file('spotless/freshmark.gradle')

--- a/gradle.properties
+++ b/gradle.properties
@@ -1,12 +1,17 @@
 license=apache
 git_url=github.com/diffplug/image-grinder
 
-plugin_list=imageGrinder
+plugin_list=imageGrinder imageGrinderLegacy
 plugin_tags=image svg png
-plugin_imageGrinder_id=com.diffplug.gradle.image-grinder
+plugin_imageGrinder_id=com.diffplug.image-grinder
 plugin_imageGrinder_impl=com.diffplug.gradle.imagegrinder.ImageGrinderPlugin
 plugin_imageGrinder_name=Image Grinder
 plugin_imageGrinder_desc=Image manipulation for Gradle
+
+plugin_imageGrinderLegacy_id=com.diffplug.gradle.image-grinder
+plugin_imageGrinderLegacy_impl=com.diffplug.gradle.imagegrinder.ImageGrinderPlugin$Legacy
+plugin_imageGrinderLegacy_name=Back-compat alias to com.diffplug.image-grinder
+plugin_imageGrinderLegacy_desc=Back-compat alias to com.diffplug.image-grinder
 
 maven_group=com.diffplug.gradle
 maven_name=image-grinder

--- a/src/main/java/com/diffplug/gradle/imagegrinder/ImageGrinderPlugin.java
+++ b/src/main/java/com/diffplug/gradle/imagegrinder/ImageGrinderPlugin.java
@@ -28,6 +28,7 @@ public class ImageGrinderPlugin implements Plugin<Project> {
 
 	@Override
 	public void apply(Project project) {
+		project.getPlugins().apply(Legacy.class);
 		project.getExtensions().add(NAME, project.container(ImageGrinderTask.class, new NamedDomainObjectFactory<ImageGrinderTask>() {
 			@Override
 			public ImageGrinderTask create(String name) {
@@ -39,5 +40,13 @@ public class ImageGrinderPlugin implements Plugin<Project> {
 				return task;
 			}
 		}));
+	}
+
+	/** The legacy `com.diffplug.gradle.image-grinder`, does exactly the same thing as `com.diffplug.image-grinder`. */
+	public static class Legacy implements Plugin<Project> {
+		@Override
+		public void apply(Project project) {
+			project.getPlugins().apply(ImageGrinderPlugin.class);
+		}
 	}
 }

--- a/src/main/java/com/diffplug/gradle/imagegrinder/ImageGrinderPlugin.java
+++ b/src/main/java/com/diffplug/gradle/imagegrinder/ImageGrinderPlugin.java
@@ -47,6 +47,9 @@ public class ImageGrinderPlugin implements Plugin<Project> {
 		@Override
 		public void apply(Project project) {
 			project.getPlugins().apply(ImageGrinderPlugin.class);
+			System.out.println("  plugin id 'com.diffplug.gradle.image-grinder' has been deprecated");
+			System.out.println("replaced by 'com.diffplug.image-grinder'");
+			System.out.println("A simple find-replace will fix it.  Here is why we moved: https://dev.to/nedtwigg/names-in-java-maven-and-gradle-2fm2#gradle-plugin-id");
 		}
 	}
 }


### PR DESCRIPTION
After creating the PR, please add a commit that adds a bullet-point under the `-SNAPSHOT` section of [CHANGES.md](https://github.com/diffplug/image-grinder/blob/master/CHANGES.md) that includes:

- [ ] a summary of the change
- [ ] a link to the newly created PR

This makes it easier for the maintainers to quickly release your changes.
