### PR TITLE
Fix the configuration cache support.

### DIFF
--- a/CHANGES.md
+++ b/CHANGES.md
@@ -1,8 +1,10 @@
 # ImageGrinder
 
 ## [Unreleased]
+### Fixed
+- Now supports the Gradle Configuration Cache, but we had to lose support for incremental build ([#9](https://github.com/diffplug/image-grinder/pull/9)).
 
-## [2.2.0] - 2021-09-04
+## [2.2.0] - 2021-09-04 [YANKED]
 ### Added
 - Now supports the Gradle Configuration Cache ([#8](https://github.com/diffplug/image-grinder/pull/8)).
   - This required bumping our minimum required Gradle from `5.6` to `6.0`.

--- a/README.md
+++ b/README.md
@@ -49,7 +49,8 @@ imageGrinder {
 
 Every single file in `srcDir` needs to be an image that ImageGrinder can parse.  Each image will be parsed, and wrapped into an [`Img`](https://javadoc.io/doc/com.diffplug.gradle/image-grinder/2.2.0/com/diffplug/gradle/imagegrinder/Img.html). Call its methods to grind it into whatever you need in the `dstDir`.
 
-ImageGrinder uses the gradle [Worker API](https://docs.gradle.org/6.0/userguide/custom_tasks.html#worker_api) introduced in Gradle 5.6 to use all your CPU cores for grinding.  It also uses gradle's [incremental task](https://docs.gradle.org/6.0/userguide/custom_tasks.html#incremental_tasks) support to do the minimum amount of grinding required. And if you're using the [configuration cache](https://docs.gradle.org/6.6/userguide/configuration_cache.html) introduced in Gradle 6.6, that'll work too for near-instant startup times.
+ImageGrinder uses the gradle [Worker API](https://docs.gradle.org/6.6/userguide/custom_tasks.html#worker_api) to use all your CPU cores for grinding, the [buildcache](https://docs.gradle.org/6.6/userguide/build_cache.html) to minimize the necessary work, and it also supports the [configuration cache](https://docs.gradle.org/6.6/userguide/configuration_cache.html) for near-instant startup times. It does not currently support [incremental update](https://docs.gradle.org/6.0/userguide/custom_tasks.html#incremental_tasks), but if you go back to `2.1.3` you can get that back in return for losing the configuration cache (see [#9](https://github.com/diffplug/image-grinder/pull/9) for details).
+
 
 ## Configuration avoidance
 

--- a/src/main/java/com/diffplug/gradle/imagegrinder/ImageGrinderPlugin.java
+++ b/src/main/java/com/diffplug/gradle/imagegrinder/ImageGrinderPlugin.java
@@ -16,7 +16,9 @@
 package com.diffplug.gradle.imagegrinder;
 
 
+import com.diffplug.common.base.Errors;
 import java.io.File;
+import java.io.IOException;
 import org.gradle.api.NamedDomainObjectFactory;
 import org.gradle.api.Plugin;
 import org.gradle.api.Project;
@@ -34,7 +36,17 @@ public class ImageGrinderPlugin implements Plugin<Project> {
 			@Override
 			public ImageGrinderTask create(String name) {
 				ImageGrinderTask task = project.getTasks().create(name, ImageGrinderTask.class);
-				task.getCacheFile().set(new File(project.getBuildDir(), "cache" + name));
+				File mappingIn = new File(project.getBuildDir(), "mappingIn" + name);
+				if (!mappingIn.exists()) {
+					try {
+						mappingIn.getParentFile().mkdirs();
+						mappingIn.createNewFile();
+					} catch (IOException e) {
+						throw Errors.asRuntime(e);
+					}
+				}
+				task.getMappingFileIn().set(mappingIn);
+				task.getMappingFileOut().set(new File(project.getBuildDir(), "mappingOut" + name));
 				if (name.startsWith("process")) {
 					Task processResources = project.getTasks().getByName(JavaPlugin.PROCESS_RESOURCES_TASK_NAME);
 					processResources.dependsOn(task);

--- a/src/main/java/com/diffplug/gradle/imagegrinder/ImageGrinderPlugin.java
+++ b/src/main/java/com/diffplug/gradle/imagegrinder/ImageGrinderPlugin.java
@@ -16,9 +16,6 @@
 package com.diffplug.gradle.imagegrinder;
 
 
-import com.diffplug.common.base.Errors;
-import java.io.File;
-import java.io.IOException;
 import org.gradle.api.NamedDomainObjectFactory;
 import org.gradle.api.Plugin;
 import org.gradle.api.Project;
@@ -36,17 +33,6 @@ public class ImageGrinderPlugin implements Plugin<Project> {
 			@Override
 			public ImageGrinderTask create(String name) {
 				ImageGrinderTask task = project.getTasks().create(name, ImageGrinderTask.class);
-				File mappingIn = new File(project.getBuildDir(), "mappingIn" + name);
-				if (!mappingIn.exists()) {
-					try {
-						mappingIn.getParentFile().mkdirs();
-						mappingIn.createNewFile();
-					} catch (IOException e) {
-						throw Errors.asRuntime(e);
-					}
-				}
-				task.getMappingFileIn().set(mappingIn);
-				task.getMappingFileOut().set(new File(project.getBuildDir(), "mappingOut" + name));
 				if (name.startsWith("process")) {
 					Task processResources = project.getTasks().getByName(JavaPlugin.PROCESS_RESOURCES_TASK_NAME);
 					processResources.dependsOn(task);

--- a/src/main/java/com/diffplug/gradle/imagegrinder/ImageGrinderPlugin.java
+++ b/src/main/java/com/diffplug/gradle/imagegrinder/ImageGrinderPlugin.java
@@ -16,6 +16,7 @@
 package com.diffplug.gradle.imagegrinder;
 
 
+import java.io.File;
 import org.gradle.api.NamedDomainObjectFactory;
 import org.gradle.api.Plugin;
 import org.gradle.api.Project;
@@ -33,7 +34,7 @@ public class ImageGrinderPlugin implements Plugin<Project> {
 			@Override
 			public ImageGrinderTask create(String name) {
 				ImageGrinderTask task = project.getTasks().create(name, ImageGrinderTask.class);
-				task.getBuildDir().set(project.getBuildDir());
+				task.getCacheFile().set(new File(project.getBuildDir(), "cache" + name));
 				if (name.startsWith("process")) {
 					Task processResources = project.getTasks().getByName(JavaPlugin.PROCESS_RESOURCES_TASK_NAME);
 					processResources.dependsOn(task);

--- a/src/main/java/com/diffplug/gradle/imagegrinder/ImageGrinderTask.java
+++ b/src/main/java/com/diffplug/gradle/imagegrinder/ImageGrinderTask.java
@@ -16,36 +16,24 @@
 package com.diffplug.gradle.imagegrinder;
 
 
-import com.diffplug.common.collect.HashMultimap;
 import java.io.File;
-import java.io.IOException;
 import java.io.Serializable;
-import java.nio.file.Files;
-import java.nio.file.StandardCopyOption;
 import java.util.Objects;
 import java.util.Random;
-import java.util.Set;
 import javax.inject.Inject;
 import org.gradle.api.Action;
 import org.gradle.api.DefaultTask;
 import org.gradle.api.file.DirectoryProperty;
 import org.gradle.api.file.FileSystemOperations;
-import org.gradle.api.file.FileType;
 import org.gradle.api.file.RegularFileProperty;
 import org.gradle.api.provider.Property;
 import org.gradle.api.tasks.CacheableTask;
 import org.gradle.api.tasks.Input;
 import org.gradle.api.tasks.InputDirectory;
-import org.gradle.api.tasks.InputFile;
 import org.gradle.api.tasks.OutputDirectory;
-import org.gradle.api.tasks.OutputFile;
 import org.gradle.api.tasks.PathSensitive;
 import org.gradle.api.tasks.PathSensitivity;
 import org.gradle.api.tasks.TaskAction;
-import org.gradle.work.ChangeType;
-import org.gradle.work.FileChange;
-import org.gradle.work.Incremental;
-import org.gradle.work.InputChanges;
 import org.gradle.workers.WorkAction;
 import org.gradle.workers.WorkParameters;
 import org.gradle.workers.WorkQueue;
@@ -61,19 +49,6 @@ import org.slf4j.LoggerFactory;
  * Worker requires that all arguments to its worker runnables ({@link ImageGrinderTask}
  * in this case) be Serializable.  There's no way to serialize our {@link #grinder(Action)}, so we had
  * to use {@link SerializableRef} to sneakily pass our task to the worker.
- * 
- * ## Tedious thing #2: Removal handling
- * 
- * Tedious thing #2: .java to .class has a 1:1 mapping.  But that is not true for these images - a pipeline
- * might create two images from one source, and the number of outputs might even change based on the content
- * of the input (e.g. skip hi-res versions of very large images).
- * 
- * That means that when the user removes or changes an image, we need to remember exactly which files it
- * created last time, or else we might end up with stale results lying around.  So, this task has the
- * {@link #map} field which is a multimap from source file to the dst files it created.  When the task starts,
- * it reads this map from disk, and when the task finishes, it writes it to disk.  Whenever an {@link Img} is
- * rendered, the filename that was written is saved to this map via the {@link Img#registerDstFile(String)}
- * method.
  */
 @CacheableTask
 public abstract class ImageGrinderTask extends DefaultTask {
@@ -84,13 +59,6 @@ public abstract class ImageGrinderTask extends DefaultTask {
 		this.workerExecutor = workerExecutor;
 	}
 
-	@InputFile
-	public abstract RegularFileProperty getMappingFileIn();
-
-	@OutputFile
-	public abstract RegularFileProperty getMappingFileOut();
-
-	@Incremental
 	@PathSensitive(PathSensitivity.RELATIVE)
 	@InputDirectory
 	public abstract DirectoryProperty getSrcDir();
@@ -121,68 +89,19 @@ public abstract class ImageGrinderTask extends DefaultTask {
 	public abstract FileSystemOperations getFs();
 
 	@TaskAction
-	public void performAction(InputChanges inputChanges) throws Exception {
+	public void performAction() throws Exception {
 		Objects.requireNonNull(grinder, "grinder");
+		getFs().delete(deleteSpec -> deleteSpec.delete(getDstDir()));
 
-		if (!inputChanges.isIncremental()) {
-			getFs().delete(deleteSpec -> deleteSpec.delete(getMappingFileIn()));
-			map = HashMultimap.create();
-		} else {
-			readMappingIn();
-		}
 		WorkQueue queue = workerExecutor.noIsolation();
-		for (FileChange fileChange : inputChanges.getFileChanges(getSrcDir())) {
-			if (fileChange.getFileType() == FileType.DIRECTORY) {
-				continue;
-			}
-			boolean modifiedOrRemoved = fileChange.getChangeType() == ChangeType.MODIFIED || fileChange.getChangeType() == ChangeType.REMOVED;
-			boolean modifiedOrAdded = fileChange.getChangeType() == ChangeType.MODIFIED || fileChange.getChangeType() == ChangeType.ADDED;
-			if (modifiedOrRemoved) {
-				logger.info("clean: " + fileChange.getNormalizedPath());
-				remove(fileChange.getFile());
-			}
-			if (modifiedOrAdded) {
-				logger.info("render: " + fileChange.getNormalizedPath());
-				queue.submit(RenderSvg.class, params -> {
-					params.getSourceFile().set(fileChange.getFile());
-					params.getTaskRef().set(SerializableRef.create(ImageGrinderTask.this));
-				});
-			}
-		}
-		queue.await();
-		writeMappingOut();
-	}
-
-	private void remove(File srcFile) {
-		synchronized (map) {
-			Set<File> toDelete = map.removeAll(srcFile);
-			getFs().delete(spec -> {
-				spec.delete(toDelete.toArray());
+		getSrcDir().get().getAsFileTree().visit(fileVisit -> {
+			logger.info("render: " + fileVisit.getRelativePath());
+			queue.submit(RenderSvg.class, params -> {
+				params.getSourceFile().set(fileVisit.getFile());
+				params.getTaskRef().set(SerializableRef.create(ImageGrinderTask.this));
 			});
-		}
-	}
-
-	public boolean debug = false;
-
-	HashMultimap<File, File> map;
-
-	@SuppressWarnings("unchecked")
-	private void readMappingIn() {
-		File cacheFile = getMappingFileIn().getAsFile().get();
-		if (cacheFile.exists()) {
-			map = SerializableMisc.fromFile(HashMultimap.class, cacheFile);
-		} else {
-			map = HashMultimap.create();
-		}
-	}
-
-	private void writeMappingOut() throws IOException {
-		synchronized (map) {
-			File out = getMappingFileOut().getAsFile().get();
-			File in = getMappingFileIn().getAsFile().get();
-			SerializableMisc.toFile(map, out);
-			Files.copy(out.toPath(), in.toPath(), StandardCopyOption.REPLACE_EXISTING);
-		}
+		});
+		queue.await();
 	}
 
 	public interface RenderSvgParams extends WorkParameters {

--- a/src/main/java/com/diffplug/gradle/imagegrinder/Img.java
+++ b/src/main/java/com/diffplug/gradle/imagegrinder/Img.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2020 DiffPlug
+ * Copyright (C) 2020-2021 DiffPlug
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
@@ -83,9 +83,10 @@ public abstract class Img<T extends Size.Has> implements Size.Has {
 	File registerDstFile(String fullPath) {
 		File file = new File(task.getDstDir().getAsFile().get(), fullPath);
 		FileMisc.mkdirs(file.getParentFile());
-		synchronized (task.map) {
-			task.map.put(new File(task.getSrcDir().getAsFile().get(), subpath.full()), file);
-		}
+		// TODO: useful for incremental build in the future, perhaps
+		//		synchronized (task.map) {
+		//			task.map.put(new File(task.getSrcDir().getAsFile().get(), subpath.full()), file);
+		//		}
 		return file;
 	}
 

--- a/src/main/java/com/diffplug/gradle/imagegrinder/Subpath.java
+++ b/src/main/java/com/diffplug/gradle/imagegrinder/Subpath.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2020 DiffPlug
+ * Copyright (C) 2020-2021 DiffPlug
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
@@ -18,17 +18,34 @@ package com.diffplug.gradle.imagegrinder;
 
 import com.diffplug.common.base.Preconditions;
 import java.io.File;
+import org.gradle.api.file.FileSystemLocationProperty;
 
 public class Subpath {
 	private final String full;
 	private final String extension;
 	private final String withoutExtension;
 
+	public static Subpath from(FileSystemLocationProperty<?> root, FileSystemLocationProperty<?> child) {
+		return from(root.getAsFile().get(), child.getAsFile().get());
+	}
+
+	public static Subpath from(FileSystemLocationProperty<?> root, File child) {
+		return from(root.getAsFile().get(), child);
+	}
+
 	public static Subpath from(File root, File child) {
 		String rootPath = root.getAbsolutePath().replace('\\', '/') + '/';
 		String childPath = child.getAbsolutePath().replace('\\', '/');
 		Preconditions.checkArgument(childPath.startsWith(rootPath), "%s needs to start with %s", childPath, rootPath);
 		return new Subpath(childPath.substring(rootPath.length()));
+	}
+
+	public File resolve(File root) {
+		return new File(root, full);
+	}
+
+	public File resolve(FileSystemLocationProperty<?> root) {
+		return resolve(root.getAsFile().get());
 	}
 
 	public String full() {
@@ -61,5 +78,22 @@ public class Subpath {
 		Preconditions.checkArgument(idx >= 0, "'%s' must contain a '.'", subpath);
 		Preconditions.checkArgument(idx < subpath.length() - 1, "'%s' can't end in '.'", subpath);
 		return subpath.substring(idx + 1);
+	}
+
+	@Override
+	public int hashCode() {
+		return full.hashCode();
+	}
+
+	@Override
+	public boolean equals(Object other) {
+		if (other == this) {
+			return true;
+		} else if (other instanceof Subpath) {
+			Subpath sub = (Subpath) other;
+			return sub.full.equals(full);
+		} else {
+			return false;
+		}
 	}
 }

--- a/src/test/java/com/diffplug/gradle/imagegrinder/ImageGrinderPluginSizeDependentTest.java
+++ b/src/test/java/com/diffplug/gradle/imagegrinder/ImageGrinderPluginSizeDependentTest.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2020 DiffPlug
+ * Copyright (C) 2020-2021 DiffPlug
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
@@ -46,11 +46,13 @@ public class ImageGrinderPluginSizeDependentTest extends GradleHarness {
 		// this image is 16x16, so it should be rendered with HiDPI
 		write("src/refresh.svg", readTestResource("refresh.svg"));
 		runAndAssert(TaskOutcome.SUCCESS);
+		runAndAssert(TaskOutcome.SUCCESS);
 		runAndAssert(TaskOutcome.UP_TO_DATE);
 		assertFolderContent("dst").containsExactly("refresh.png", "refresh@2x.png");
 
 		// this image is large, so it should only have a 1x rendering
 		write("src/refresh.svg", readTestResource("refresh-large.svg"));
+		runAndAssert(TaskOutcome.SUCCESS);
 		runAndAssert(TaskOutcome.SUCCESS);
 		runAndAssert(TaskOutcome.UP_TO_DATE);
 		assertFolderContent("dst").containsExactly("refresh.png");

--- a/src/test/java/com/diffplug/gradle/imagegrinder/ImageGrinderPluginSizeDependentTest.java
+++ b/src/test/java/com/diffplug/gradle/imagegrinder/ImageGrinderPluginSizeDependentTest.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (C) 2020-2021 DiffPlug
+ * Copyright 2020 DiffPlug
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
@@ -46,13 +46,11 @@ public class ImageGrinderPluginSizeDependentTest extends GradleHarness {
 		// this image is 16x16, so it should be rendered with HiDPI
 		write("src/refresh.svg", readTestResource("refresh.svg"));
 		runAndAssert(TaskOutcome.SUCCESS);
-		runAndAssert(TaskOutcome.SUCCESS);
 		runAndAssert(TaskOutcome.UP_TO_DATE);
 		assertFolderContent("dst").containsExactly("refresh.png", "refresh@2x.png");
 
 		// this image is large, so it should only have a 1x rendering
 		write("src/refresh.svg", readTestResource("refresh-large.svg"));
-		runAndAssert(TaskOutcome.SUCCESS);
 		runAndAssert(TaskOutcome.SUCCESS);
 		runAndAssert(TaskOutcome.UP_TO_DATE);
 		assertFolderContent("dst").containsExactly("refresh.png");

--- a/src/test/java/com/diffplug/gradle/imagegrinder/ImageGrinderPluginTest.java
+++ b/src/test/java/com/diffplug/gradle/imagegrinder/ImageGrinderPluginTest.java
@@ -92,12 +92,14 @@ public class ImageGrinderPluginTest extends GradleHarness {
 
 	@Test
 	public void testUpToDate() throws Exception {
+		// changing topology of files requires two builds before converging on up-to-date
 		writeBuild();
 		write("src/refresh.svg", readTestResource("refresh.svg"));
 		runAndAssert(TaskOutcome.SUCCESS);
+		runAndAssert(TaskOutcome.SUCCESS);
 		runAndAssert(TaskOutcome.UP_TO_DATE);
 
-		// if we change the file, it runs again
+		// modifying the content of an existing file allows single-run up-to-date
 		write("src/refresh.svg", readTestResource("diffpluglogo.svg"));
 		runAndAssert(TaskOutcome.SUCCESS);
 		runAndAssert(TaskOutcome.UP_TO_DATE);
@@ -127,19 +129,19 @@ public class ImageGrinderPluginTest extends GradleHarness {
 		runAndAssert(TaskOutcome.SUCCESS).containsExactly("render: refresh.svg");
 		assertFolderContent("dst").containsExactly("refresh.png", "refresh@2x.png");
 
-		// add a file, and only it changes
+		// if a file is added, we have to redo everything because the mapping changed
 		write("src/diffpluglogo.svg", readTestResource("diffpluglogo.svg"));
-		runAndAssert(TaskOutcome.SUCCESS).containsExactly("render: diffpluglogo.svg");
+		runAndAssert(TaskOutcome.SUCCESS).containsExactly("render: refresh.svg", "render: diffpluglogo.svg");
 		assertFolderContent("dst").containsExactly("diffpluglogo.png", "diffpluglogo@2x.png", "refresh.png", "refresh@2x.png");
 
-		// remove a file, and only it is removed
+		// if a file is removed, we have to redo everything because the mapping changed
 		delete("src/refresh.svg");
-		runAndAssert(TaskOutcome.SUCCESS).containsExactly("clean: refresh.svg");
+		runAndAssert(TaskOutcome.SUCCESS).containsExactly("render: diffpluglogo.svg");
 		assertFolderContent("dst").containsExactly("diffpluglogo.png", "diffpluglogo@2x.png");
 
 		// remove another file, and we end up with an empty directory
 		delete("src/diffpluglogo.svg");
-		runAndAssert(TaskOutcome.SUCCESS).containsExactly("clean: diffpluglogo.svg");
+		runAndAssert(TaskOutcome.SUCCESS).containsExactly();
 		assertFolderContent("dst").isEmpty();
 
 		// add them both, and they're both rendered
@@ -147,5 +149,15 @@ public class ImageGrinderPluginTest extends GradleHarness {
 		write("src/diffpluglogo.svg", readTestResource("diffpluglogo.svg"));
 		runAndAssert(TaskOutcome.SUCCESS).containsExactlyInAnyOrder("render: refresh.svg", "render: diffpluglogo.svg");
 		assertFolderContent("dst").containsExactly("diffpluglogo.png", "diffpluglogo@2x.png", "refresh.png", "refresh@2x.png");
+
+		// with no changes, we still get one rerender because the mapping changed
+		runAndAssert(TaskOutcome.SUCCESS).containsExactlyInAnyOrder("render: refresh.svg", "render: diffpluglogo.svg");
+		// but after that it's up-to-date
+		runAndAssert(TaskOutcome.UP_TO_DATE).containsExactlyInAnyOrder();
+
+		// and if we change just a single file, then we finally get the advantage of incremental build
+		write("src/refresh.svg", readTestResource("diffpluglogo.svg"));
+		runAndAssert(TaskOutcome.SUCCESS).containsExactlyInAnyOrder("clean: refresh.svg", "render: refresh.svg");
+		runAndAssert(TaskOutcome.UP_TO_DATE).containsExactlyInAnyOrder();
 	}
 }

--- a/src/test/java/com/diffplug/gradle/imagegrinder/ImageGrinderPluginTest.java
+++ b/src/test/java/com/diffplug/gradle/imagegrinder/ImageGrinderPluginTest.java
@@ -117,35 +117,4 @@ public class ImageGrinderPluginTest extends GradleHarness {
 		runAndAssert(TaskOutcome.SUCCESS);
 		runAndAssert(TaskOutcome.UP_TO_DATE);
 	}
-
-	@Test
-	public void testIncremental() throws Exception {
-		writeBuild();
-
-		// one file
-		write("src/refresh.svg", readTestResource("refresh.svg"));
-		runAndAssert(TaskOutcome.SUCCESS).containsExactly("render: refresh.svg");
-		assertFolderContent("dst").containsExactly("refresh.png", "refresh@2x.png");
-
-		// add a file, and only it changes
-		write("src/diffpluglogo.svg", readTestResource("diffpluglogo.svg"));
-		runAndAssert(TaskOutcome.SUCCESS).containsExactly("render: diffpluglogo.svg");
-		assertFolderContent("dst").containsExactly("diffpluglogo.png", "diffpluglogo@2x.png", "refresh.png", "refresh@2x.png");
-
-		// remove a file, and only it is removed
-		delete("src/refresh.svg");
-		runAndAssert(TaskOutcome.SUCCESS).containsExactly("clean: refresh.svg");
-		assertFolderContent("dst").containsExactly("diffpluglogo.png", "diffpluglogo@2x.png");
-
-		// remove another file, and we end up with an empty directory
-		delete("src/diffpluglogo.svg");
-		runAndAssert(TaskOutcome.SUCCESS).containsExactly("clean: diffpluglogo.svg");
-		assertFolderContent("dst").isEmpty();
-
-		// add them both, and they're both rendered
-		write("src/refresh.svg", readTestResource("refresh.svg"));
-		write("src/diffpluglogo.svg", readTestResource("diffpluglogo.svg"));
-		runAndAssert(TaskOutcome.SUCCESS).containsExactlyInAnyOrder("render: refresh.svg", "render: diffpluglogo.svg");
-		assertFolderContent("dst").containsExactly("diffpluglogo.png", "diffpluglogo@2x.png", "refresh.png", "refresh@2x.png");
-	}
 }


### PR DESCRIPTION
`2.2.0` was supposed to add support for configuration cache, but was actually broken. This PR fixes it, but at the following cost:

- a single input SVG can produce 0 to n output files
- because of this, our task has to maintain the mapping from input to output files manually, there isn't a guaranteed 1 -> 1
- previously, we did this with a locally mutable cache, which was always a risky choice
- now we have an `InputFile mappingFileIn` and `OutputFile mappingFileOut`, the last step of the task is to write `mappingFileOut` and copy it back to `mappingFileIn`
- this means that whenever the file topology changes (files added, removed, or changed in a way that affects the number of output files), we have to a full rerun of the task. Incremental only works when on pure modifications, no change in number of outputs.

~Overall not a big deal.~ EDIT: See next comment.